### PR TITLE
docs: add output file location information

### DIFF
--- a/docs/user-guide/getting-started/running.md
+++ b/docs/user-guide/getting-started/running.md
@@ -78,6 +78,17 @@ RAPID produces the following outputs:
 - **Discharge time series** (`Qou_ncf`): Routed discharge for all time steps
 - **Final state** (`Qfi_ncf`): Final discharge values for model restart
 
+### Finding Your Results
+
+After a successful run, output files will be written to the paths you specified in your namelist configuration. The output location is determined by the `Qou_ncf` and `Qfi_ncf` parameters in your YAML file.
+
+For the Sandbox example from the [Quick Start](../../quick-start.md) guide, results can be found at:
+
+- `./output/Sandbox/Qout_Sandbox_19700101_19700110.nc4` - discharge time series
+- `./output/Sandbox/Qfinal_Sandbox_19700101_19700110.nc4` - final state for model restart
+
+Make sure the output directories exist before running RAPID, or the program will fail to write results.
+
 ## Command Line Options
 
 RAPID accepts the following command line arguments:

--- a/docs/user-guide/quick-start.md
+++ b/docs/user-guide/quick-start.md
@@ -37,6 +37,13 @@ rapid2 -nl input/Sandbox/namelist_Sandbox.yml
 
 That's it!
 
+## Viewing Results
+
+After a successful run, your output files will be written to the paths specified in the namelist configuration. For the Sandbox example, check:
+
+- `./output/Sandbox/Qout_Sandbox_19700101_19700110.nc4` - discharge time series
+- `./output/Sandbox/Qfinal_Sandbox_19700101_19700110.nc4` - final state for model restart
+
 ## Need More?
 
 For step-by-step setup details, see the [User Guide](getting-started/installation.md).


### PR DESCRIPTION
## Summary

- Added "Viewing Results" section to Quick Start page
- Added "Finding Your Results" subsection to Running page  
- Both sections explicitly show users where to find output files after running RAPID
- Includes specific example paths for the Sandbox use case

## Changes

**docs/user-guide/quick-start.md:**
- Added new section after Quick Run explaining where Sandbox output files are located

**docs/user-guide/getting-started/running.md:**
- Added subsection under Output Files explaining how output locations are determined
- Included Sandbox example paths and note about creating output directories

Fixes [#19](https://github.com/c-h-david/rapid2/issues/19)