### PR TITLE
Update docs for rapid2 CLI flag consistency

### DIFF
--- a/docs/user-guide/getting-started/installation.md
+++ b/docs/user-guide/getting-started/installation.md
@@ -86,14 +86,19 @@ rapid2 --help
 
 **Expected Output:**
 ```
-usage: rapid2 [-h] -nl NAMELIST
+usage: rapid2 [-h] [--version] -nml NAMELIST
 
-This is RAPID2
+Routing Application for Programmed Integration of Discharge (RAPID).
 
 options:
   -h, --help            show this help message and exit
-  -nl, --namelist NAMELIST
-                        Specify the namelist value
+  --version             show program's version number and exit
+  -nml NAMELIST, --namelist NAMELIST
+                        specify the namelist file
+
+examples:
+  rapid2 --namelist input/Sandbox/namelist_Sandbox.yml
+  rapid2 --namelist input/Tutorial/namelist_Tutorial.yml
 ```
 
 If you see this output, RAPID has been successfully installed!

--- a/docs/user-guide/getting-started/running.md
+++ b/docs/user-guide/getting-started/running.md
@@ -5,12 +5,6 @@
 RAPID uses a YAML configuration file (namelist) to specify input files, parameters, and output locations. The basic command to run RAPID is:
 
 ```bash
-rapid2 -nl namelist.yml
-```
-
-or
-
-```bash
 rapid2 --namelist namelist.yml
 ```
 
@@ -93,7 +87,7 @@ Make sure the output directories exist before running RAPID, or the program will
 
 RAPID accepts the following command line arguments:
 
-- `-nl, --namelist`: Path to the YAML namelist file (required)
+- `-nml, --namelist`: Path to the YAML namelist file (required)
 
 ## Important Note About Input Data
 

--- a/docs/user-guide/quick-start.md
+++ b/docs/user-guide/quick-start.md
@@ -32,7 +32,7 @@ cd ..
 Run RAPID.
 
 ```bash
-rapid2 -nl input/Sandbox/namelist_Sandbox.yml
+rapid2 --namelist input/Sandbox/namelist_Sandbox.yml
 ```
 
 That's it!


### PR DESCRIPTION
Updates CLI flag references across quick-start, installation, and running docs to match the rapid2 flag consistency changes — replacing `-nl` with `-nml`/`--namelist`, updating the expected help output, and using long flag names in all examples. See c-h-david/rapid2#35.